### PR TITLE
added a new public function to help create public key

### DIFF
--- a/public_key.go
+++ b/public_key.go
@@ -88,6 +88,21 @@ func DeserializeCompressed(curve EllipticCurve, serialized []byte) (*PublicKey, 
 		Y:     y}}, nil
 }
 
+// NewKey creates a new public key
+func NewKey(curve elliptic.Curve, x *big.Int, y *big.Int) *PublicKey {
+	if x == nil || y == nil {
+		return nil
+	}
+	return &PublicKey{
+		publicKey: &ecdsa.PublicKey{
+			Curve: curve,
+			X:     x,
+			Y:     y,
+		},
+	}
+
+}
+
 func (pbk *PublicKey) Serialize() []byte {
 	return elliptic.Marshal(pbk.publicKey.Curve, pbk.publicKey.X, pbk.publicKey.Y)
 }

--- a/public_key_test.go
+++ b/public_key_test.go
@@ -1,6 +1,9 @@
 package easyecc
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"fmt"
 	"math/big"
 	"testing"
@@ -146,4 +149,49 @@ func Test_PublicKey_BitcoinEthereumAddress(t *testing.T) {
 	assert.Equal(ErrUnsupportedCurve, err)
 	_, err = wrongCurveKey.PublicKey().EthereumAddress()
 	assert.Equal(ErrUnsupportedCurve, err)
+}
+
+func TestNewKey(t *testing.T) {
+	randomBigInt := func(bitSize int) *big.Int {
+		max := new(big.Int)
+		max.Exp(big.NewInt(2), big.NewInt(int64(bitSize)), nil).Sub(max, big.NewInt(1))
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return nil
+		}
+		return n
+	}
+	x := randomBigInt(256)
+	y := randomBigInt(256)
+	type args struct {
+		curve elliptic.Curve
+		x     *big.Int
+		y     *big.Int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *PublicKey
+	}{
+		{
+			name: "valid input",
+			args: args{curve: elliptic.P256(), x: x, y: y},
+			want: &PublicKey{publicKey: &ecdsa.PublicKey{elliptic.P256(), x, y}},
+		},
+		{
+			name: "invalid input x",
+			args: args{curve: elliptic.P256(), x: nil, y: y},
+			want: nil,
+		},
+		{
+			name: "invalid input y",
+			args: args{curve: elliptic.P256(), x: x, y: nil},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, NewKey(tt.args.curve, tt.args.x, tt.args.y), "NewKey(%v, %v, %v)", tt.args.curve, tt.args.x, tt.args.y)
+		})
+	}
 }


### PR DESCRIPTION
Problem: 
I was creating a solution that utilises the existing keys but easyecc does not allow the creation of the public key using Curve, X and Y values. 

Solution:
A new function (NewKey) is added to set up a new public key.

Commit: 
contains a new function and a unit test.

Please let me know if you rather have a different name for the function, e.g. New instead of NewKey.